### PR TITLE
Integration with JSComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Support node build-in module's method completion(`ctrl-x ctrl-o`) in `js` file w
 Download the [tarball](https://github.com/myhere/vim-nodejs-complete/zipball/master) and extract to your vimfiles(`~/.vim` or `~/vimfiles`) folder.
 
 Completion require `:filetype plugin on`, please make sure it's on.
+For integration with [jscomplete](https://github.com/teramako/jscomplete-vim), set `let g:node_usejscomplete = 1`. *Note*: you must install jscomplete manually.
 
 
 ## Example

--- a/after/autoload/nodejscomplete.vim
+++ b/after/autoload/nodejscomplete.vim
@@ -8,7 +8,11 @@ let s:nodejs_doc_file = expand('<sfile>:p:h') . '/nodejs-doc.vim'
 
 function! nodejscomplete#CompleteJS(findstart, base)
   if a:findstart
-    let start = javascriptcomplete#CompleteJS(a:findstart, a:base)
+    if exists('g:node_usejscomplete') && g:node_usejscomplete
+      let start = jscomplete#CompleteJS(a:findstart, a:base)
+    else
+      let start = javascriptcomplete#CompleteJS(a:findstart, a:base)
+    endif
 
     " complete context
     let line = getline('.')
@@ -17,7 +21,11 @@ function! nodejscomplete#CompleteJS(findstart, base)
     return start
   else
     let nodeCompl = s:findNodeComplete(a:base)
-    let jsCompl = javascriptcomplete#CompleteJS(a:findstart, a:base)
+    if exists('g:node_usejscomplete') && g:node_usejscomplete
+      let jsCompl = jscomplete#CompleteJS(a:findstart, a:base)
+    else
+      let jsCompl = javascriptcomplete#CompleteJS(a:findstart, a:base)
+    endif
 
     return nodeCompl + jsCompl
   endif


### PR DESCRIPTION
I've added integration with [jscomplete](https://github.com/teramako/jscomplete-vim), instead of vim's default javascriptcomplete.
